### PR TITLE
マジックコマンドとその他処理混在

### DIFF
--- a/nbtester/loader.py
+++ b/nbtester/loader.py
@@ -45,7 +45,13 @@ def load_cells(variables, nb_path, cell_indexes=None):
         action="ignore",
         category=ImportWarning
     )
-    repl = r'if "\g<command>" == "run": load_cells(locals(), "\g<args>")'
+    def repl(m):
+        command, args = m.groups()
+        if command != 'run':
+            return ''
+        fnam = os.path.join(os.path.dirname(nb_path), args)
+        return 'load_cells(locals(), "%s")' % fnam
+    
     for cell in code_cells:
         source = cell['source']
 


### PR DESCRIPTION
・%runをload_cellsに変換、その他のマジックコマンドは無視。
・セル内にマジックコマンドと通常処理が混在しても、両方処理される。